### PR TITLE
Fix golangci-lint revive and unparam errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,12 +17,8 @@ linters:
   settings:
     gocritic:
       enabled-checks:
-        - appendAssign
         - boolExprSimplify
-        - dupBranchBody
-        - dupCase
         - equalFold
-        - exitAfterDefer
         - hugeParam
         - indexAlloc
         - initClause
@@ -31,7 +27,6 @@ linters:
         - rangeExprCopy
         - ruleguard
         - truncateCmp
-        - underef
         - unnamedResult
     revive:
       rules:

--- a/collector/lastlog.go
+++ b/collector/lastlog.go
@@ -42,6 +42,7 @@ func (c *LastlogCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.descLastlog
 }
 
+// Collect implements prometheus.Collector.
 func (c *LastlogCollector) Collect(ch chan<- prometheus.Metric) {
 	c.mu.RLock()
 	needsRefresh := time.Since(c.cacheTime) >= c.cacheTTL

--- a/collector/resources.go
+++ b/collector/resources.go
@@ -21,6 +21,7 @@ type ResourceCollector struct {
 	descProc *prometheus.Desc
 }
 
+// NewResourceCollector creates a new ResourceCollector.
 func NewResourceCollector(cfg Config) *ResourceCollector {
 	return &ResourceCollector{
 		cfg: cfg,
@@ -42,12 +43,14 @@ func NewResourceCollector(cfg Config) *ResourceCollector {
 	}
 }
 
+// Describe implements prometheus.Collector.
 func (c *ResourceCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.descCPU
 	ch <- c.descMem
 	ch <- c.descProc
 }
 
+// Collect implements prometheus.Collector.
 func (c *ResourceCollector) Collect(ch chan<- prometheus.Metric) {
 	resources, err := collectUserResources(context.Background())
 	if err != nil {

--- a/collector/sessions.go
+++ b/collector/sessions.go
@@ -35,6 +35,7 @@ type SessionCollector struct {
 	lastUsers []string // cached active usernames from last Collect
 }
 
+// NewSessionCollector creates a new SessionCollector.
 func NewSessionCollector(cfg Config) *SessionCollector {
 	return &SessionCollector{
 		cfg: cfg,
@@ -51,16 +52,18 @@ func NewSessionCollector(cfg Config) *SessionCollector {
 	}
 }
 
+// Describe implements prometheus.Collector.
 func (c *SessionCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.descLogged
 	ch <- c.descSession
 }
 
+// Collect implements prometheus.Collector.
 func (c *SessionCollector) Collect(ch chan<- prometheus.Metric) {
 	var allSessions []Session
 
 	// Collect from all sources, tolerating individual failures
-	if ptySessions, err := collectWhoSessions(context.Background(), c.cfg.Logger); err == nil {
+	if ptySessions, err := collectWhoSessions(context.Background()); err == nil {
 		allSessions = append(allSessions, ptySessions...)
 	} else {
 		c.cfg.Logger.Error("failed to collect PTY sessions", "err", err)
@@ -128,7 +131,7 @@ func (c *SessionCollector) ActiveUsers() []string {
 
 // collectWhoSessions parses the output of the `who` command.
 // Output format: "username  pts/0  2024-01-15 09:32 (192.168.1.10)"
-func collectWhoSessions(ctx context.Context, logger *slog.Logger) ([]Session, error) {
+func collectWhoSessions(ctx context.Context) ([]Session, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "who").Output()
@@ -240,7 +243,7 @@ func collectNonPTYSSH(ctx context.Context, logger *slog.Logger, cache *UserLooku
 
 // resolveVNCUser resolves the username for a VNC connection from the ss process field.
 // Falls back to finding the Xvnc process listening on the given local port.
-func resolveVNCUser(processField string, localPort int, logger *slog.Logger, cache *UserLookupCache) string {
+func resolveVNCUser(processField string, localPort int, cache *UserLookupCache) string {
 	if processField != "" {
 		matches := ssPIDRegex.FindStringSubmatch(processField)
 		if len(matches) >= 2 {
@@ -250,7 +253,7 @@ func resolveVNCUser(processField string, localPort int, logger *slog.Logger, cac
 		}
 	}
 	if localPort > 0 {
-		return resolveVNCOwner(context.Background(), localPort, logger, cache)
+		return resolveVNCOwner(context.Background(), localPort, cache)
 	}
 	return ""
 }
@@ -281,7 +284,7 @@ func collectVNCSessions(ctx context.Context, logger *slog.Logger, cache *UserLoo
 		localAddr, peerAddr, processField := parseSSFields(fields)
 		localPort := extractPort(localAddr)
 
-		username := resolveVNCUser(processField, localPort, logger, cache)
+		username := resolveVNCUser(processField, localPort, cache)
 		if username == "" {
 			continue
 		}
@@ -347,7 +350,7 @@ func resolveProcessUser(pid string, cache *UserLookupCache) (string, error) {
 
 // resolveVNCOwner finds the Xvnc/Xtigervnc process listening on the given port
 // and returns its owner username.
-func resolveVNCOwner(ctx context.Context, port int, logger *slog.Logger, cache *UserLookupCache) string {
+func resolveVNCOwner(ctx context.Context, port int, cache *UserLookupCache) string {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	// Find the listening process on this specific port

--- a/collector/ssh.go
+++ b/collector/ssh.go
@@ -19,6 +19,7 @@ type SSHCollector struct {
 	vncCountFn func() (int, error)
 }
 
+// NewSSHCollector creates a new SSHCollector.
 func NewSSHCollector(cfg Config, vncCountFn func() (int, error)) *SSHCollector {
 	return &SSHCollector{
 		cfg: cfg,
@@ -36,11 +37,13 @@ func NewSSHCollector(cfg Config, vncCountFn func() (int, error)) *SSHCollector {
 	}
 }
 
+// Describe implements prometheus.Collector.
 func (c *SSHCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.descSSH
 	ch <- c.descRemote
 }
 
+// Collect implements prometheus.Collector.
 func (c *SSHCollector) Collect(ch chan<- prometheus.Metric) {
 	sshCount, err := countSSHConnections(context.Background())
 	if err != nil {

--- a/collector/userinfo.go
+++ b/collector/userinfo.go
@@ -11,6 +11,7 @@ type UserInfoCollector struct {
 	activeUsersFn func() []string
 }
 
+// NewUserInfoCollector creates a new UserInfoCollector.
 func NewUserInfoCollector(cfg Config, activeUsersFn func() []string) *UserInfoCollector {
 	return &UserInfoCollector{
 		cfg: cfg,
@@ -23,10 +24,12 @@ func NewUserInfoCollector(cfg Config, activeUsersFn func() []string) *UserInfoCo
 	}
 }
 
+// Describe implements prometheus.Collector.
 func (c *UserInfoCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.descInfo
 }
 
+// Collect implements prometheus.Collector.
 func (c *UserInfoCollector) Collect(ch chan<- prometheus.Metric) {
 	users := c.activeUsersFn()
 

--- a/collector/vnc.go
+++ b/collector/vnc.go
@@ -21,6 +21,7 @@ type VNCCollector struct {
 	count int // cached count from last Collect or CountVNC call
 }
 
+// NewVNCCollector creates a new VNCCollector.
 func NewVNCCollector(cfg Config) *VNCCollector {
 	return &VNCCollector{
 		cfg: cfg,
@@ -32,10 +33,12 @@ func NewVNCCollector(cfg Config) *VNCCollector {
 	}
 }
 
+// Describe implements prometheus.Collector.
 func (c *VNCCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.descVNC
 }
 
+// Collect implements prometheus.Collector.
 func (c *VNCCollector) Collect(ch chan<- prometheus.Metric) {
 	count, err := c.countVNCConnections(context.Background())
 	if err != nil {


### PR DESCRIPTION
  Add doc comments to all exported collector constructors, Describe, and
  Collect methods. Remove unused logger parameter from collectWhoSessions,
  resolveVNCUser, and resolveVNCOwner. Clean up redundant gocritic checks.